### PR TITLE
[Fix] 機能修正

### DIFF
--- a/app/controllers/cart_products_controller.rb
+++ b/app/controllers/cart_products_controller.rb
@@ -12,7 +12,8 @@ class CartProductsController < ApplicationController
     if @cart_product.update(cart_product_params)
       redirect_to user_cart_products_path
     else
-      render :index
+      redirect_to user_cart_products_path
+      flash[:notice] = "※1以上の個数を選択してください"
     end
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -29,11 +29,16 @@ class OrdersController < ApplicationController
       @order.name = params[:name1]
       @order.telephone = params[:telephone1]
     when "2" then
-      @receiver_select = Receiver.find(params[:full_address_id])
-      @order.postal = @receiver_select.postal
-      @order.address = @receiver_select.address
-      @order.name = @receiver_select.name
-      @order.telephone = params[:telephone2]
+      if params[:fill_address_id].nil?
+        redirect_to new_order_path
+        flash[:notice] = "※お届け先を選択してください"
+      else
+        @receiver_select = Receiver.find(params[:full_address_id])
+        @order.postal = @receiver_select.postal
+        @order.address = @receiver_select.address
+        @order.name = @receiver_select.name
+        @order.telephone = params[:telephone2]
+      end
     when "3" then
       if params[:postal3] == "" || params[:address3] == "" || params[:name3] == ""
         redirect_to new_order_path

--- a/app/models/cart_product.rb
+++ b/app/models/cart_product.rb
@@ -1,4 +1,6 @@
 class CartProduct < ApplicationRecord
 	belongs_to :user
 	belongs_to :product
+
+	validates :number, presence: true
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,14 +1,14 @@
 class Product < ApplicationRecord
 	has_many :order_products
 	has_many :cart_products, dependent: :destroy
-	belongs_to :genre, optional: true 
+	belongs_to :genre, optional: true
 
 
 	validates :genres_id, presence: true
 	validates :name, presence: true
 	validates :introduction, presence: true
 	validates :no_tax, presence: true
-	validates :sale_status, presence: true
+	validates :sale_status, inclusion: { in: [true, false] }
 	#defaultでtrueが入っている
 	#商品新規登録画面では「販売」「売切」の２択で表示する「選択してください」は含めない
 

--- a/app/views/admin/products/edit.html.erb
+++ b/app/views/admin/products/edit.html.erb
@@ -50,7 +50,7 @@
 			<div class="row">
 				<p class="col-md-3">販売<br>ステータス</p>
 				<div class="col-md-6">
-					<%= f.select :sale_status,[["販売中", true], ["売切れ", false]],{}, class: "form-control" %>
+					<%= f.select :sale_status, [['販売中','true'],['売切れ','false']],{}, class: "form-control" %>
 				</div>
 			</div>
 

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -40,7 +40,7 @@
                 <%= link_to product_path(product) do %>
                 <%= product.name %><br>
               <% end %>
-              ¥<%= product.no_tax.to_s(:delimited) %>
+              ¥<%= include_tax(product.no_tax) %>
             </div>
           <% end %>
           </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -30,11 +30,18 @@
         	<div class="row">
         		<div class="col-md-5 col-md-offset-7">
                     <!--サインイン時の表示-->
-                <% if user_signed_in? %>
+                <% if user_signed_in? && @product.sale_status == true %>
                     <%= form_for [@user, @cart_product] do |f| %>
                         <%= f.select :number, [[1, 1],[2, 2],[3, 3],[4, 4],[5, 5],[6, 6],[7, 7],[8, 8],[9, 9],[10, 10]] %>
                         <%= f.hidden_field :product_id, :value => @product.id %>
                         <%= f.submit "カートに入れる", class: 'btn btn-primary active' %>
+                    <% end %>
+                <% else %>
+                    <% if user_signed_in? %>
+                      <p style="color:red;">※現在品切れ中</p>
+                    <% else %>
+                      <%= link_to "会員登録して購入", new_user_registration_path, class: 'btn btn-sm btn-success active' %>
+                      <%= link_to "ログインして購入", new_user_session_path, class: 'btn btn-sm btn-primary active' %>
                     <% end %>
                 <% end %>
             	</div>


### PR DESCRIPTION
・カート内商品個数　空白では変更できないよう修正
・注文情報確認画面　登録済配達先のタブのデフォルト値では注文できないよう変更
・管理側商品情報編集画面　sale_statusを変更できるよう修正
・ユーザー側商品詳細画面　未ログイン時→登録・ログインボタン表示に変更　sale_statusがfalseの場合→売切れ表示に変更