### PR TITLE
[Fix] ジャンル無効の商品詳細表示しない 

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,12 +2,12 @@ class ProductsController < ApplicationController
 
   def index
     @genres = Genre.where(status: true)
-    #@genres = Genre.all
+    @product_count = Product.all.count
     if params[:search]
-      @products = Product.where(products_search_params).page(params[:page]).per(10)
+      @products = Product.where(products_search_params).page(params[:page]).per(8)
       @genreid = params[:genres_id_var]
     else
-      @products = Product.where(genre_status: true).page(params[:page]).per(10)
+      @products = Product.where(genre_status: true).page(params[:page]).per(8)
     end
   end
 
@@ -15,9 +15,11 @@ class ProductsController < ApplicationController
   	@genres = Genre.all
   	@product = Product.find(params[:id])
   	@user = current_user
+    redirect_to products_path if Genre.find(@product.genres_id).status == false
     if user_signed_in?
   	 @cart_product = @user.cart_products.new
     end
+
   end
 
   private

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -30,7 +30,7 @@
             商品
           <% end %>
           一覧
-          <span class="count">(全<%= @products.count %>件)</span>
+          <span class="count">(全<%= @product_count %>件)</span>
         </h3>
         <div class="container item-box">
           <div class="row item-box-sizing">


### PR DESCRIPTION
商品indexで 全N件 表示が、1ページ分しか表示されなかったため製品数が出るように修正
商品indexのページネーションを10→8件に修正