### PR TITLE
[Add/Fix] 機能追加・修正

### DIFF
--- a/app/assets/stylesheets/admin/home/top.scss
+++ b/app/assets/stylesheets/admin/home/top.scss
@@ -1,10 +1,7 @@
-.admin-top-main {
-	padding: 50px;
-}
 .admin-top-title {
-	margin: 50px 0;
 	font-weight: bold;
 }
+
 .admin-top-content {
-	margin: 100px 0;
+	margin-top: 30px;
 }

--- a/app/assets/stylesheets/users/_campeign.scss
+++ b/app/assets/stylesheets/users/_campeign.scss
@@ -1,0 +1,6 @@
+.campeign-text {
+	line-height: 30px;
+	text-align: center;
+	background-color: #DC143C;
+	color: #FFFFF0;
+}

--- a/app/assets/stylesheets/users/_header.scss
+++ b/app/assets/stylesheets/users/_header.scss
@@ -52,7 +52,7 @@
   .flash {
     color: #FF0000;
     font-size: 20px;
-    padding: 20px 120px;
+    padding: 10px 120px;
   }
 
 }

--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -3,6 +3,7 @@ class Admin::HomeController < ApplicationController
 	before_action :authenticate_admin! , only:[:top]
 
   def top
-  	@orders = Order.where(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day)
+  	@daily_orders = Order.where(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day)
+  	@monthly_orders = Order.where(created_at: Time.zone.now.beginning_of_month..Time.zone.now.end_of_month)
   end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -3,12 +3,19 @@ class Admin::OrdersController < ApplicationController
   before_action :authenticate_admin! , only:[:index, :show]
 
   def index
-    if params[:page_serect] == "1" then
-      @order = Order.where(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).page(params[:page]).per(10)
-    elsif params[:page_serect] == "2" then
-      @order = Order.all.page(params[:page]).per(10)
-    elsif params[:page_serect] == "3" then
-      @order = Order.where(user_id: params[:user_serect]).page(params[:page]).per(10)
+    if params[:page_select] == "1" then
+      @orders = Order.where(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).order(created_at: :desc).page(params[:page]).per(10)
+      @title = "#{Date.today}の注文一覧"
+    elsif params[:page_select] == "2" then
+      @orders = Order.all.order(created_at: :desc).page(params[:page]).per(10)
+      @title = "注文一覧"
+    elsif params[:page_select] == "3" then
+      @orders = Order.where(user_id: params[:user_select]).order(created_at: :desc).page(params[:page]).per(10)
+      @user = User.find_by(id: params[:user_select])
+      @title = "#{@user.lastname + @user.firstname} 様の注文一覧"
+    elsif params[:page_select] == "4" then
+      @orders = Order.where(created_at: Time.zone.now.beginning_of_month..Time.zone.now.end_of_month).order(created_at: :desc).page(params[:page]).per(10)
+      @title = "#{Date.today.month}月の注文一覧"
     else
     end
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,6 @@ class ProductsController < ApplicationController
 
   def index
     @genres = Genre.where(status: true)
-    @product_count = Product.all.count
     if params[:search]
       @products = Product.where(products_search_params).page(params[:page]).per(8)
       @genreid = params[:genres_id_var]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,6 +32,13 @@ class UsersController < ApplicationController
   end
 
   def confirm
+    @orders = current_user.orders.all
+    @orders.each do |order|
+      if order.order_status == "入金待ち"
+        flash[:notice] = "※お支払いが完了していない注文が存在するため退会できません"
+        redirect_to edit_user_path(current_user) and return
+      end
+    end
   end
 
   private

--- a/app/views/admin/home/_header.html.erb
+++ b/app/views/admin/home/_header.html.erb
@@ -17,7 +17,7 @@
 					<li class="header-link"><%= link_to "会員一覧",
 						admin_users_path %></li>
 					<li class="header-link"><%= link_to "注文履歴一覧",
-						admin_orders_path(page_serect: "2") %></li>
+						admin_orders_path(page_select: "2") %></li>
 					<li class="header-link"><%= link_to "ジャンル管理",
 						admin_genres_path %></li>
           <li class="header-link"><%= link_to "ログアウト",

--- a/app/views/admin/home/top.html.erb
+++ b/app/views/admin/home/top.html.erb
@@ -2,11 +2,36 @@
 
 <div class="container">
 	<div class="row">
-		<div class="col-md-12 admin-top-main">
-			<h2 class="admin-top-title">管理者画面</h2>
-			<h2 class="admin-top-content">
-				本日の注文件数　　　<%= link_to "#{@orders.count}", admin_orders_path(page_serect: "1") %>　件
-			</h2>
-		</div>
+		<h2 class="admin-top-title">管理者画面</h2>
+	</div>
+	<div class="row admin-top-content">
+		<h2 class="daily-sales-order">
+			<%= Date.today %>の注文件数
+			<%= link_to "#{@daily_orders.count}", admin_orders_path(page_select: "1") %>　件
+		</h2>
+	</div>
+	<div class="row admin-top-content">
+		<% daily_sales = 0 %>
+		<h2 class="daily-sales-price">
+			<% @daily_orders.each do |daily_order| %>
+			<% daily_sales += daily_order.total_products %>
+			<% end %>
+			<%= Date.today %>の売上金額　　<%= daily_sales.to_s(:delimited, delimiter: ',') %>　円
+		</h2>
+	</div>
+	<div class="row admin-top-content">
+		<h2 class="monthly-sales-order">
+			<%= Date.today.month %>月の注文件数
+			<%= link_to "#{@monthly_orders.count}", admin_orders_path(page_select: "4") %>　件
+		</h2>
+	</div>
+	<div class="row admin-top-content">
+		<% monthly_sales = 0 %>
+		<h2 class="monthly-sales-price">
+			<% @monthly_orders.each do |monthly_order| %>
+			<% monthly_sales += monthly_order.total_products %>
+			<% end %>
+			<%= Date.today.month %>月の売上金額　　<%= monthly_sales.to_s(:delimited, delimiter: ',') %>　円
+		</h2>
 	</div>
 </div>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -2,25 +2,29 @@
 
 <div class="container" id="admin-order-index">
 	<div class="row">
-		<div class="col-md-3">
-			<h3>注文一覧画面</h3>
+		<div class="col-md-5">
+			<h3><%= @title %></h3>
 		</div>
 	</div>
 	<div class="row">
-		<div class="col-md-6 col-md-offset-3">
+		<div class="col-md-10 col-md-offset-1">
 			<table class="table table-bordered">
 				<tr>
-					<th>購入日時</th><th>購入者</th><th>注文個数</th><th>注文ステータス</th><th></th>
+					<th class="col-md-3">購入日時</th>
+					<th class="col-md-3">購入者</th>
+					<th class="col-md-2">注文個数</th>
+					<th class="col-md-2">注文ステータス</th>
+					<th class="col-md-2"></th>
 				</tr>
 				<tbody>
-					<% @order.each do |order| %>
+					<% @orders.each do |order| %>
 						<% total_var = 0 %>
 						<% order.order_products.each do |order_product| %>
 						<% total_var = total_var + order_product.number %>
 						<% end %>
 						<tr>
 							<td><%= order.created_at %></td>
-							<td><%= order.name %></td>
+							<td><%= order.user.lastname + order.user.firstname %></td>
 							<td><%= total_var %></td>
 							<td><%= order.order_status %></td>
 							<td><%= link_to "注文詳細",admin_order_path(order.id), class: "btn btn-primary" %></td>
@@ -29,9 +33,9 @@
 				</tbody>
 			</table>
 
-			<div class="paginate">
-      			<%= paginate @order %>
-    		</div>
+			<div class="paginate col-md-offset-2">
+      	<%= paginate @orders %>
+    	</div>
 
 		</div>
 	</div>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -71,13 +71,12 @@
 					<td><%= o.price.to_s(:delimited, delimiter: ',') %></td>
 					<td><%= o.number %></td>
 					<td><%= (o.price * o.number).to_s(:delimited, delimiter: ',') %></td>
-					<% total_price_var = o.price * o.number %>
+					<% total_price_var += o.price * o.number %>
 					<%= form_tag admin_order_path(@order.id,switch_status: 2,send_production_id: o.id), method: :patch do %>
 					<td>
 						<%= select_tag :send_production_status, options_for_select([["着手不可",:着手不可],["製作待ち",:製作待ち],["製作中",:製作中],["製作完了",:製作完了]],o.production_status),style: "width:100%" %>
 					</td>
-
-						<td style="text-align:center"><%= submit_tag "更新", class: "btn btn-primary" %></td>
+					<td style="text-align:center"><%= submit_tag "更新", class: "btn btn-primary" %></td>
 					<% end %>
 				</tr>
 				<% end %>

--- a/app/views/admin/products/edit.html.erb
+++ b/app/views/admin/products/edit.html.erb
@@ -43,7 +43,7 @@
 			<div class="row">
 				<p class="col-md-3">税抜価格</p>
 				<div class="col-md-6">
-					<%= f.text_field :no_tax, class: "panel panel-default edit-form" %>
+					<%= f.number_field :no_tax, step: 10, class: "panel panel-default edit-form" %>
 				</div>
 			</div>
 

--- a/app/views/admin/products/new.html.erb
+++ b/app/views/admin/products/new.html.erb
@@ -43,7 +43,7 @@
 			<div class="row">
 				<p class="col-md-3">税抜価格</p>
 				<div class="col-md-9">
-					<%= f.text_field :no_tax, class: "panel panel-default admin-product-new-form" %>
+					<%= f.number_field :no_tax, step: 10, class: "panel panel-default admin-product-new-form" %>
 				</div>
 			</div>
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -24,7 +24,9 @@
 									<%= link_to user.lastname + user.firstname, admin_user_path(user.id) %>
 								</td>
 								<td><%= user.email %></td>
-								<td><%= user.status %></td>
+								<td>
+									<%= user.status == true ? "有効" : "無効" %>
+								</td>
 							</tr>
 						<% end %>
 					</tbody>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -52,7 +52,7 @@
         
         <div class="row bottan-box">
           <%= link_to "編集する", edit_admin_user_path, class: 'btn btn-primary' %>
-          <%= link_to "注文履歴一覧を見る", admin_orders_path(page_serect: "3", user_serect: @user.id), class: 'btn btn-primary orders-bottan' %>
+          <%= link_to "注文履歴一覧を見る", admin_orders_path(page_select: "3", user_select: @user.id), class: 'btn btn-primary orders-bottan' %>
         </div>
 
       </div>

--- a/app/views/cart_products/index.html.erb
+++ b/app/views/cart_products/index.html.erb
@@ -1,4 +1,5 @@
 <%= render 'users/header' %>
+<%= render 'users/campeign' %>
 
 <div class="container">
 	<div class="row">

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -40,8 +40,8 @@
                         <td style="padding-right: 15px">
                             <%= link_to (product) do %>
                                 <%= attachment_image_tag product, :image, size: "160x110", fallback: "noimage.jpg" %><br>
+                                <%= product.name %><br>
                             <% end %>
-                            <%= link_to product.name, product_path(product) %><br>
                             ¥<%= include_tax(product.no_tax) %><br>
                         </td>
                         <% end %>

--- a/app/views/orders/confirm.html.erb
+++ b/app/views/orders/confirm.html.erb
@@ -1,4 +1,5 @@
 <%= render 'users/header' %>
+<%= render 'users/campeign' %>
 
 <div class="container">
 	<div class="row">
@@ -37,7 +38,15 @@
 			<table class="table table-bordered">
 				<tr>
 					<th class="orders-list-title">送料</th>
-					<td>800<%= f.hidden_field :fee, :value => 800 %></td>
+					<td>
+						<% if total >= 5000 %>
+							<% fee = 0 %>
+							<%= fee %><%= f.hidden_field :fee, :value => fee %>
+						<% else %>
+							<% fee = 800 %>
+							<%= fee %><%= f.hidden_field :fee, :value => fee %>
+						<% end %>
+					</td>
 				</tr>
 				<tr>
 					<th class="orders-list-title">商品合計</th>
@@ -49,8 +58,8 @@
 				<tr>
 					<th class="orders-list-title">請求金額</th>
 					<td>
-						<%= (total + 800).to_s(:delimited, delimiter: ',') %>
-						<%= f.hidden_field :total_pay, :value => (total + 800).to_i %>
+						<%= (total + fee).to_s(:delimited, delimiter: ',') %>
+						<%= f.hidden_field :total_pay, :value => (total + fee).to_i %>
 					</td>
 				</tr>
 			</table>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -30,7 +30,7 @@
             商品
           <% end %>
           一覧
-          <span class="count">(全<%= @product_count %>件)</span>
+          <span class="count">(全<%= @products.count %>件)</span>
         </h3>
         <div class="container item-box">
           <div class="row item-box-sizing">

--- a/app/views/users/_campeign.html.erb
+++ b/app/views/users/_campeign.html.erb
@@ -1,0 +1,5 @@
+<div class="container campeign-box">
+	<div class="row campeign-info">
+		<h4 class="campeign-text col-md-12">税込5,000円以上で送料無料</h4>
+	</div>
+</div>


### PR DESCRIPTION
・管理側トップ　当日の売上額、当月の注文件数・売上額表示追加
当月の注文件数リンクからは、orders/indexページで当月の注文のみ表示されるよう変更済
・ユーザー側　税込5,000円以上で送料無料となる機能追加
カートと購入確定前確認ページに部分テンプレート(users/_campeign)で案内表示
・管理側orders/index　表示内容によってタイトルも変更されるよう変更
注文の表示順を:descに変更(新しい注文を上に表示)、レイアウト調整、「注文者名」欄に配達先名が表示されていた点を修正、変数名等修正
・管理側orders/show　商品合計が1つの商品のみの金額になっていた点を修正
・管理側user/index　会員ステータス　ビュー上での英語表記(true/false)→日本語(有効/無効)に変更
・ユーザー側users/edit　order_statusが入金待ちの注文がある場合、退会不可に変更