### PR TITLE
[Add/Fix] 表示変更

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -4,9 +4,11 @@ class ProductsController < ApplicationController
     @genres = Genre.where(status: true)
     if params[:search]
       @products = Product.where(products_search_params).page(params[:page]).per(8)
+      @products_count = Product.where(products_search_params)
       @genreid = params[:genres_id_var]
     else
       @products = Product.where(genre_status: true).page(params[:page]).per(8)
+      @products_count = Product.where(genre_status: true)
     end
   end
 

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,17 +1,17 @@
 module ProductsHelper
   def include_tax(no_tax)
-    price = no_tax * 1.1
-    price.floor.to_s(:delimited, delimiter: ',')
+    price = (no_tax * 1.1).round
+    price.to_s(:delimited, delimiter: ',')
   end
 
   def get_subtotal(no_tax, number)
-		price = no_tax * 1.1
-		subtotal = price.floor * number
+		price = (no_tax * 1.1).round
+		subtotal = price * number
 		subtotal.to_s(:delimited, delimiter: ',')
 	end
 
 	def total_price(no_tax, number)
-		price = no_tax * 1.1
-		subtotal = price.floor * number
+		price = (no_tax * 1.1).round
+		subtotal = price * number
 	end
 end

--- a/app/views/admin/products/edit.html.erb
+++ b/app/views/admin/products/edit.html.erb
@@ -43,7 +43,7 @@
 			<div class="row">
 				<p class="col-md-3">税抜価格</p>
 				<div class="col-md-6">
-					<%= f.number_field :no_tax, step: 10, class: "panel panel-default edit-form" %>
+					<%= f.number_field :no_tax, class: "panel panel-default edit-form" %>
 				</div>
 			</div>
 

--- a/app/views/admin/products/edit.html.erb
+++ b/app/views/admin/products/edit.html.erb
@@ -43,7 +43,14 @@
 			<div class="row">
 				<p class="col-md-3">税抜価格</p>
 				<div class="col-md-6">
-					<%= f.number_field :no_tax, class: "panel panel-default edit-form" %>
+					<%= f.number_field :no_tax, class: "panel panel-default edit-form", id: "no-tax" %>
+				</div>
+			</div>
+
+			<div class="row">
+				<p class="col-md-3">（税込価格）</p>
+				<div class="col-md-6">
+					<input type="number" class="panel panel-default" id="with-tax"></input>
 				</div>
 			</div>
 
@@ -63,5 +70,19 @@
 
 	</div> <!--row-->
 	<% end %>
+
+	<script>
+		$('#no-tax').change(function(){
+			var price = $('#no-tax').val();
+			var withTax = price * 1.1;
+			$('#with-tax').val(Math.round(withTax));
+		});
+
+		$('#with-tax').change(function(){
+			var price = $('#with-tax').val();
+			var noTax = price / 1.1;
+			$('#no-tax').val(Math.round(noTax));
+		});
+	</script>
 
 </div>

--- a/app/views/admin/products/new.html.erb
+++ b/app/views/admin/products/new.html.erb
@@ -43,7 +43,14 @@
 			<div class="row">
 				<p class="col-md-3">税抜価格</p>
 				<div class="col-md-9">
-					<%= f.number_field :no_tax, step: 10, class: "panel panel-default admin-product-new-form" %>
+					<%= f.number_field :no_tax, class: "panel panel-default admin-product-new-form", id: "no-tax" %>
+				</div>
+			</div>
+
+			<div class="row">
+				<p class="col-md-3">（税込価格）</p>
+				<div class="col-md-9">
+					<input type="number" class="panel panel-default" id="with-tax"></input>
 				</div>
 			</div>
 
@@ -57,10 +64,24 @@
 
 		<!--新規登録ボタン	-->
 		<div class="col-md-2">
-			<%= f.submit "新規登録",class: "btn btn-primary admin-product-new-submit" %>	
+			<%= f.submit "新規登録",class: "btn btn-primary admin-product-new-submit" %>
 		</div>
 
 	</div> <!--row-->
 	<% end %>
+
+	<script>
+		$('#no-tax').change(function(){
+			var price = $('#no-tax').val();
+			var withTax = price * 1.1;
+			$('#with-tax').val(Math.round(withTax));
+		});
+
+		$('#with-tax').change(function(){
+			var price = $('#with-tax').val();
+			var noTax = price / 1.1;
+			$('#no-tax').val(Math.round(noTax));
+		});
+	</script>
 
 </div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -30,7 +30,7 @@
             商品
           <% end %>
           一覧
-          <span class="count">(全<%= @products.count %>件)</span>
+          <span class="count">(全<%= @products_count.count %>件)</span>
         </h3>
         <div class="container item-box">
           <div class="row item-box-sizing">


### PR DESCRIPTION
[Fix]
・ユーザー側商品一覧画面　〜一覧(全◯件)の表示が8件までしか表示されない点を修正（ページネーション設定している変数を使って表示させていたため）
・admin側で表示される税込金額とユーザー側で表示される税込金額が異なっていた（税率計算方法に相違）点を修正
[Add]
・admin側 商品新規登録/編集画面　税込金額の入力フォームを作成
税込価格→税抜価格を同ページ内で算出でき、価格設定が簡単に行える仕様に変更